### PR TITLE
Add a sample page to load a Word Document in Immersive Reader

### DIFF
--- a/js/samples/advanced-csharp/Pages/Document.cshtml
+++ b/js/samples/advanced-csharp/Pages/Document.cshtml
@@ -43,6 +43,7 @@
         <a href='/multilang'>Multilingual Document</a>
         <a href='/uilangs'>UI Language</a>
         <a href='/math'>Math</a>
+        <a href='/worddoc'>Word Document</a>
     </nav>
 
     <header class='ir-button-area' style='padding-left: 100px'>

--- a/js/samples/advanced-csharp/Pages/Index.cshtml
+++ b/js/samples/advanced-csharp/Pages/Index.cshtml
@@ -76,6 +76,7 @@
         <a href='/multilang'>Multilingual Document</a>
         <a href='/uilangs'>UI Language</a>
         <a href='/math'>Math</a>
+        <a href='/worddoc'>Word Document</a>
     </nav>
     <main id='ContentArea'>
         <section class='section' id='Sample1'>

--- a/js/samples/advanced-csharp/Pages/Math.cshtml
+++ b/js/samples/advanced-csharp/Pages/Math.cshtml
@@ -73,6 +73,7 @@
         <a href='/multilang'>Multilingual Document</a>
         <a href='/uilangs'>UI Language</a>
         <a href='/math' class='active'>Math</a>
+        <a href='/worddoc'>Word Document</a>
     </nav>
 
     <main id='ContentArea'>

--- a/js/samples/advanced-csharp/Pages/MultiLang.cshtml
+++ b/js/samples/advanced-csharp/Pages/MultiLang.cshtml
@@ -44,6 +44,7 @@
         <a href='/multilang' class='active'>Multilingual Document</a>
         <a href='/uilangs'>UI Language</a>
         <a href='/math'>Math</a>
+        <a href='/worddoc'>Word Document</a>
     </nav>
 
     <header class='ir-button-area' style='padding-left: 100px'>

--- a/js/samples/advanced-csharp/Pages/UILangs.cshtml
+++ b/js/samples/advanced-csharp/Pages/UILangs.cshtml
@@ -74,6 +74,7 @@
         <a href='/multilang'>Multilingual Document</a>
         <a href='/uilangs' class='active'>UI Language</a>
         <a href='/math'>Math</a>
+        <a href='/worddoc'>Word Document</a>
     </nav>
 
     <main id='ContentArea'>

--- a/js/samples/advanced-csharp/Pages/WordDoc.cshtml
+++ b/js/samples/advanced-csharp/Pages/WordDoc.cshtml
@@ -1,0 +1,90 @@
+﻿@page
+@model AdvancedSampleWebApp.Pages.WordDocModel
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+
+<!doctype html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>Immersive Reader Example: Loading a Word Document</title>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+
+    <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
+    <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.2.js'></script>
+    <script type='text/javascript' src='~/js/helpers.js'></script>
+
+    <link href='~/css/styles.css' rel='stylesheet'>
+    <link href='~/css/buttons.css' rel='stylesheet'>
+
+    <script type='text/javascript'>
+        var Canary = '@Html.Raw(ViewData["Canary"])';
+    </script>
+
+    <style type='text/css'>
+        #ContentArea {
+            margin: 0 auto;
+            position: relative;
+            width: 100%;
+        }
+
+        #IRContent {
+            margin: 0 100px;
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        Examples:
+        <a href='/index'>Sections</a>
+        <a href='/document' class='active'>Document</a>
+        <a href='/multilang'>Multilingual Document</a>
+        <a href='/uilangs'>UI Language</a>
+        <a href='/math'>Math</a>
+        <a href='/worddoc'>Word Document</a>
+    </nav>
+
+    <main id='ContentArea'>
+        <label for="post-docxFile">Launch a Word Doc in Immersive Reader:</label>
+        <div>
+            <input class="btn" type="file" id="post-docxFile" name="file" onchange="launchUploadedDocx(this)" />
+        </div>
+    </main>
+
+    <script type='text/javascript'>
+        function launchUploadedDocx(input) {
+            var reader = new FileReader();
+
+            reader.onloadend = function (evt) {
+                // This method is triggered after the reader.readAsBinaryString() completes.
+                var base64EncodedFile = window.btoa(reader.result);
+
+                const data = {
+                    title: input.value.toString(),
+                    chunks: [{
+                        content: base64EncodedFile,
+                        lang: 'en',
+                        mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' // Word Docx mimetype
+                    }]
+                };
+
+                launchImmersiveReader(data);
+            }
+
+            if (!input.value.toString().endsWith(".docx")) {
+                alert("You must choose a .docx file");
+            } else {
+                reader.readAsBinaryString(input.files[0]);
+            }
+        }
+
+        async function launchImmersiveReader(data) {
+            const token = await getImmersiveReaderTokenAsync(Canary);
+            const subdomain = await getImmersiveReaderSubdomainAsync();
+
+            ImmersiveReader.launchAsync(token, subdomain, data);
+        }
+    </script>
+</body>
+</html>

--- a/js/samples/advanced-csharp/Pages/WordDoc.cshtml.cs
+++ b/js/samples/advanced-csharp/Pages/WordDoc.cshtml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Configuration;
+
+namespace AdvancedSampleWebApp.Pages
+{
+    public class WordDocModel : SamplePageModel
+    {
+        public WordDocModel(IConfiguration configuration) : base(configuration)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Adds a page to the advanced c# sample that demonstrates how to load a Word Document (in docx format) into the Immersive Reader.