### PR TITLE
Allow hiding of back arrow option and triggerImmersiveReaderExit function

### DIFF
--- a/js/samples/advanced-nodejs/routes/views.js
+++ b/js/samples/advanced-nodejs/routes/views.js
@@ -30,4 +30,12 @@ router.get('/uilangs', function(req, res, next) {
   res.sendFile('uilangs.html', {root: viewRoot});
 });
 
+router.get('/nobackarrow', function(req, res, next) {
+  res.sendFile('no-back-arrow.html', {root: viewRoot});
+});
+
+router.get('/inner-back-arrow', function(req, res, next) {
+  res.sendFile('inner-back-arrow.html', {root: viewRoot});
+});
+
 module.exports = router;

--- a/js/samples/advanced-nodejs/views/document.html
+++ b/js/samples/advanced-nodejs/views/document.html
@@ -35,6 +35,7 @@
         <a href='/multilang'>Multilingual Document</a>
         <a href='/uilangs'>UI Language</a>
         <a href='/math'>Math</a>
+        <a href='/nobackarrow'>No Back Arrow</a>
     </nav>
 
     <header class='ir-button-area'>

--- a/js/samples/advanced-nodejs/views/inner-back-arrow.html
+++ b/js/samples/advanced-nodejs/views/inner-back-arrow.html
@@ -1,0 +1,116 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+
+<!doctype html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <title>Immersive Reader Example: Section</title>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+
+    <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
+    <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.2.js'></script>
+    <script type='text/javascript' src='../js/helpers.js'></script>
+
+    <link href='../css/styles.css' rel='stylesheet'>
+    <link href='../css/buttons.css' rel='stylesheet'>
+
+    <style media='screen' type='text/css'>
+        #ContentArea {
+            display: block;
+            margin: 0 20%;
+            padding-top: 50px;
+            width: 60%;
+        }
+
+        .section {
+            border: 1px solid #cccccc;
+            border-radius: 4px;
+            box-sizing: border-box;
+            display: block;
+            margin-bottom: 20px;
+            padding: 20px 20px 10px 20px;
+            position: relative;
+            width: 100%;
+        }
+
+        #Cols {
+            box-sizing: inherit;
+            column-count: 1;
+            column-gap: 0;
+        }
+
+        h3 {
+            margin: 0;
+            margin-top: 10px;
+            padding: 0;
+        }
+
+        p {
+            line-height: 25px;
+        }
+
+        @media screen and (min-width: 900px) {
+            #Cols {
+                column-gap: 20px;
+                column-count: 2;
+            }
+        }
+    </style>
+</head>
+
+<body class='body'>
+    <header class='ir-button-area'>
+        <button class='ir-button ir-button-wide' role='button' title='Immersive Reader' aria-label='Immersive Reader' onclick='handleLaunchImmersiveReader()'>
+            <img class='ir-button-icon' src='../images/icon.svg' />
+            <span class='ir-button-text' aria-hidden='true'>Immersive Reader</span>
+        </button>
+    </header>
+    <main id='ContentArea'>
+        <article id='IRContent'>
+            <h1 id='ir-title'>Geography</h1>
+            <span id='ir-text'>
+                <p>The study of Earth’s landforms is called physical geography. Landforms can be mountains and valleys. They can also be glaciers, lakes or rivers.</p>
+                <p>The physical features of a region are often rich in resources. Within a nation, mountain ranges become natural borders for settlement areas.</p>
+            </span>
+        </article>
+    </main>
+
+    <script type='text/javascript'>
+        async function handleLaunchImmersiveReader(sampleId) {
+            const data = {
+                title: $('#ir-title').text().trim(),
+                chunks: [{
+                    content: $('#ir-text').text().trim(),
+                    lang: 'en'
+                }]
+            };
+
+            console.log(data)
+
+            const options = {
+                'showExitArrow': false,
+                'onExit': () => { console.log("You can still have a callback function on exit."); }
+            }
+
+            const token = await getImmersiveReaderTokenAsync();
+            const subdomain = await getSubdomainAsync();
+
+            ImmersiveReader.launchAsync(token, subdomain, data, options);
+        }
+
+        function messageHandler(e) {
+            if (!e || !e.data) { return; }
+
+            if (e.data === 'ExitImmersiveReader') {
+                ImmersiveReader.triggerImmersiveReaderExit();
+            }
+        };
+
+        window.addEventListener('message', messageHandler);
+    </script>
+</body>
+
+</html>

--- a/js/samples/advanced-nodejs/views/math.html
+++ b/js/samples/advanced-nodejs/views/math.html
@@ -72,6 +72,7 @@
         <a href='/multilang'>Multilingual Document</a>
         <a href='/uilangs'>UI Language</a>
         <a href='/math' class='active'>Math</a>
+        <a href='/nobackarrow'>No Back Arrow</a>
     </nav>
 
     <main id='ContentArea'>

--- a/js/samples/advanced-nodejs/views/multilang.html
+++ b/js/samples/advanced-nodejs/views/multilang.html
@@ -37,6 +37,7 @@
         <a href='/multilang' class='active'>Multilingual Document</a>
         <a href='/uilangs'>UI Language</a>
         <a href='/math'>Math</a>
+        <a href='/nobackarrow'>No Back Arrow</a>
     </nav>
 
     <header class='ir-button-area'>

--- a/js/samples/advanced-nodejs/views/no-back-arrow.html
+++ b/js/samples/advanced-nodejs/views/no-back-arrow.html
@@ -1,0 +1,95 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+
+<!doctype html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <title>Immersive Reader Example: Section</title>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+
+    <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
+    <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.2.js'></script>
+    <script type='text/javascript' src='../js/helpers.js'></script>
+
+    <link href='../css/styles.css' rel='stylesheet'>
+    <link href='../css/buttons.css' rel='stylesheet'>
+
+    <style media='screen' type='text/css'>
+        #ContentArea {
+            display: block;
+            margin: 0 20%;
+            padding-top: 50px;
+            width: 60%;
+        }
+
+        .section {
+            border: 1px solid #cccccc;
+            border-radius: 4px;
+            box-sizing: border-box;
+            display: block;
+            margin-bottom: 20px;
+            padding: 20px 20px 10px 20px;
+            position: relative;
+            width: 100%;
+        }
+
+        .section.inner-iframe {
+            margin-top: 30px;
+            height: 400px;
+        }
+
+        #closeButton {
+            margin-top: 10px;
+            padding: 10px;
+        }
+
+        @media screen and (min-width: 900px) {
+            #Cols {
+                column-gap: 20px;
+                column-count: 2;
+            }
+        }
+    </style>
+</head>
+
+<body class='body'>
+    <nav>
+        Examples:
+        <a href='/sections'>Sections</a>
+        <a href='/document'>Document</a>
+        <a href='/multilang'>Multilingual Document</a>
+        <a href='/uilangs'>UI Language</a>
+        <a href='/math'>Math</a>
+        <a href='/nobackarrow' class='active'>No Back Arrow</a>
+    </nav>
+    <main id='ContentArea'>
+        <h1 id='ir-title'>Sample: No Back Arrow</h1>
+        <span id='ir-text'>
+            When you launch this sample, you will not see the Immersive Reader's back arrow, due to the
+            <code>showExitArrow</code> option being
+            <code>false</code>.
+            <br /> An example of when you may want to use this option, is if you render the Immersive Reader on a mobile device
+            and would prefer to control exits with the device's native back arrow.
+            <br /> You can force the Immersive Reader to close by calling
+            <code>ImmersiveReader.triggerImmersiveReaderExit()</code>
+        </span>
+        <p>
+            <button id='closeButton'>Close Immersive Reader</button>
+        </p>
+        <iframe id='iframeSample' src='inner-back-arrow' class='section inner-iframe'>
+        </iframe>
+    </main>
+
+    <script type='text/javascript'>
+        $(document).ready(function() {
+            $('#closeButton').click(function() {
+                document.getElementById('iframeSample').contentWindow.postMessage('ExitImmersiveReader');
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/js/samples/advanced-nodejs/views/sections.html
+++ b/js/samples/advanced-nodejs/views/sections.html
@@ -65,6 +65,7 @@
         <a href='/multilang'>Multilingual Document</a>
         <a href='/uilangs'>UI Language</a>
         <a href='/math'>Math</a>
+        <a href='/nobackarrow'>No Back Arrow</a>
     </nav>
     <main id='ContentArea'>
         <section class='section' id='Sample1'>

--- a/js/samples/advanced-nodejs/views/uilangs.html
+++ b/js/samples/advanced-nodejs/views/uilangs.html
@@ -64,6 +64,7 @@
         <a href='/multilang'>Multilingual Document</a>
         <a href='/uilangs' class='active'>UI Language</a>
         <a href='/math'>Math</a>
+        <a href='/nobackarrow'>No Back Arrow</a>
     </nav>
 
     <main id='ContentArea'>

--- a/js/src/immersive-reader-sdk.ts
+++ b/js/src/immersive-reader-sdk.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 import { renderButtons } from './renderButtons';
-import { launchAsync } from './launchAsync';
+import { launchAsync, triggerImmersiveReaderExit } from './launchAsync';
 
 window.addEventListener('load', () => {
     renderButtons();
 });
 
-export {renderButtons, launchAsync};
+export {renderButtons, launchAsync, triggerImmersiveReaderExit};

--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -48,6 +48,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
             timeout: 15000,  // Default to 15 seconds
             useWebview: false,
             allowFullscreen: true,
+            showExitArrow: true,
             ...options
         };
 
@@ -139,7 +140,12 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
         }
 
         const domain = options.customDomain ? options.customDomain : 'https://learningtools.onenote.com/learningtoolsapp/cognitive/';
-        let src = domain + 'reader?exitCallback=ImmersiveReader-Exit';
+        let src = domain + 'reader';
+
+        if (options.showExitArrow) {
+            src += '?exitCallback=ImmersiveReader-Exit';
+        }
+
         if (options.uiLang) {
             src += '&omkt=' + options.uiLang;
         }
@@ -153,4 +159,8 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
         // Disable body scrolling
         document.head.appendChild(noscroll);
     });
+}
+
+export function triggerImmersiveReaderExit() {
+    window.postMessage('ImmersiveReader-Exit', '*');
 }

--- a/js/src/options.ts
+++ b/js/src/options.ts
@@ -9,4 +9,5 @@ export type Options = {
     onExit?: () => any;        // Executes when the Immersive Reader exits
     customDomain?: string;     // Reserved for internal use. Custom domain where the Immersive Reader webapp is hosted (default is null).
     allowFullscreen?: boolean; // The ability to toggle fullscreen (default is true).
+    showExitArrow?: boolean; // Whether or not to show the Immersive Reader's back button arrow (default is true).
 }


### PR DESCRIPTION
An example of when you may want to set the showExitArrow option to false,, is if you render the Immersive Reader on a mobile device and would prefer to control exits with the device's native back arrow.
You can force the Immersive Reader to close by calling ImmersiveReader.triggerImmersiveReaderExit()