### PR TITLE
Add IE11 support

### DIFF
--- a/js/samples/advanced-nodejs/public/js/helpers.js
+++ b/js/samples/advanced-nodejs/public/js/helpers.js
@@ -27,3 +27,13 @@ function getSubdomainAsync() {
         });
     });
 }
+
+function launchImmersiveReader(data, options) {
+    getImmersiveReaderTokenAsync().then(function (token) {
+        getSubdomainAsync().then(function (subdomain) {
+            ImmersiveReader.launchAsync(token, subdomain, data, options).catch(function (error) {
+                console.log('there was an error', error);
+            });
+        });
+    });
+}

--- a/js/samples/advanced-nodejs/public/js/helpers.js
+++ b/js/samples/advanced-nodejs/public/js/helpers.js
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 function getImmersiveReaderTokenAsync() {
-    return new Promise((resolve, reject) => {
+    return new Promise(function (resolve, reject) {
         $.ajax({
             url: '/getimmersivereadertoken',
             type: 'GET',
-            success: token => {
+            success: function (token) {
                 resolve(token);
             },
-            error: err => {
+            error: function (err) {
                 console.log('Error in getting token!', err);
                 reject(err);
             }
@@ -18,12 +18,12 @@ function getImmersiveReaderTokenAsync() {
 }
 
 function getSubdomainAsync() {
-    return new Promise((resolve, reject) => {
+    return new Promise(function (resolve, reject) {
         $.ajax({
             url: '/subdomain',
             type: 'GET',
-            success: subdomain => { resolve(subdomain); },
-            error: err => { reject(err); }
+            success: function (subdomain) { resolve(subdomain); },
+            error: function (err) { reject(err); }
         });
     });
 }

--- a/js/samples/advanced-nodejs/views/document.html
+++ b/js/samples/advanced-nodejs/views/document.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
-    <!-- Promise polyfill is needed for IE11 support -->
+    <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 

--- a/js/samples/advanced-nodejs/views/document.html
+++ b/js/samples/advanced-nodejs/views/document.html
@@ -72,7 +72,7 @@
                 'onExit': exitCallback
             };
 
-            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers how to retrieve
             // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data, options);
 

--- a/js/samples/advanced-nodejs/views/document.html
+++ b/js/samples/advanced-nodejs/views/document.html
@@ -72,6 +72,8 @@
                 'onExit': exitCallback
             };
 
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data, options);
 
             function exitCallback() {

--- a/js/samples/advanced-nodejs/views/document.html
+++ b/js/samples/advanced-nodejs/views/document.html
@@ -11,6 +11,8 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
+    <!-- Promise polyfill is needed for IE11 support -->
+    <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 
     <link href='../css/styles.css' rel='stylesheet'>
@@ -57,25 +59,20 @@
     </main>
 
     <script type='text/javascript'>
-        async function handleLaunchImmersiveReader() {
-            const data = {
+        function handleLaunchImmersiveReader() {
+            var data = {
                 title: $('#ir-title').text().trim(),
                 chunks: [{
                     content: $('#ir-text').text().trim(),
                     lang: 'en'
                 }]
             };
-            const token = await getImmersiveReaderTokenAsync();
-            const subdomain = await getSubdomainAsync();
-
-            const options = {
+            
+            var options = {
                 'onExit': exitCallback
             };
 
-            ImmersiveReader.launchAsync(token, subdomain, data, options)
-                .catch ((error) => {
-                    console.log('there was an error', error);
-                });
+            launchImmersiveReader(data, options);
 
             function exitCallback() {
                 console.log("This is the callback function.");

--- a/js/samples/advanced-nodejs/views/hide-exit-button.html
+++ b/js/samples/advanced-nodejs/views/hide-exit-button.html
@@ -11,6 +11,8 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
+    <!-- Promise polyfill is needed for IE11 support -->
+    <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 
     <link href='../css/styles.css' rel='stylesheet'>
@@ -90,7 +92,7 @@
     <script type='text/javascript'>
         $(document).ready(function() {
             $('#closeButton').click(function() {
-                document.getElementById('iframeSample').contentWindow.postMessage('CloseImmersiveReader');
+                document.getElementById('iframeSample').contentWindow.postMessage('CloseImmersiveReader', '*');
             });
         });
     </script>

--- a/js/samples/advanced-nodejs/views/hide-exit-button.html
+++ b/js/samples/advanced-nodejs/views/hide-exit-button.html
@@ -11,7 +11,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <!-- Promise polyfill is needed for IE11 support -->
+    <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 

--- a/js/samples/advanced-nodejs/views/inner-hide-exit-button.html
+++ b/js/samples/advanced-nodejs/views/inner-hide-exit-button.html
@@ -12,7 +12,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
-    <!-- Promise polyfill is needed for IE11 support -->
+    <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 

--- a/js/samples/advanced-nodejs/views/inner-hide-exit-button.html
+++ b/js/samples/advanced-nodejs/views/inner-hide-exit-button.html
@@ -95,7 +95,7 @@
                 'onExit': function () { console.log("You can still have a callback function on exit."); }
             }
 
-            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers how to retrieve
             // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data, options);
         }

--- a/js/samples/advanced-nodejs/views/inner-hide-exit-button.html
+++ b/js/samples/advanced-nodejs/views/inner-hide-exit-button.html
@@ -95,6 +95,8 @@
                 'onExit': function () { console.log("You can still have a callback function on exit."); }
             }
 
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data, options);
         }
 

--- a/js/samples/advanced-nodejs/views/inner-hide-exit-button.html
+++ b/js/samples/advanced-nodejs/views/inner-hide-exit-button.html
@@ -12,6 +12,8 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
+    <!-- Promise polyfill is needed for IE11 support -->
+    <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 
     <link href='../css/styles.css' rel='stylesheet'>
@@ -79,7 +81,7 @@
     </main>
 
     <script type='text/javascript'>
-        async function handleLaunchImmersiveReader(sampleId) {
+        function handleLaunchImmersiveReader(sampleId) {
             const data = {
                 title: $('#ir-title').text().trim(),
                 chunks: [{
@@ -90,13 +92,10 @@
 
             const options = {
                 'hideExitButton': true,
-                'onExit': () => { console.log("You can still have a callback function on exit."); }
+                'onExit': function () { console.log("You can still have a callback function on exit."); }
             }
 
-            const token = await getImmersiveReaderTokenAsync();
-            const subdomain = await getSubdomainAsync();
-
-            ImmersiveReader.launchAsync(token, subdomain, data, options);
+            launchImmersiveReader(data, options);
         }
 
         function messageHandler(e) {

--- a/js/samples/advanced-nodejs/views/math.html
+++ b/js/samples/advanced-nodejs/views/math.html
@@ -180,7 +180,7 @@
                 chunks: chunks
             };
 
-            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers how to retrieve
             // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data);
         }

--- a/js/samples/advanced-nodejs/views/math.html
+++ b/js/samples/advanced-nodejs/views/math.html
@@ -12,7 +12,7 @@
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
-    <!-- Promise polyfill is needed for IE11 support -->
+    <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 

--- a/js/samples/advanced-nodejs/views/math.html
+++ b/js/samples/advanced-nodejs/views/math.html
@@ -180,6 +180,8 @@
                 chunks: chunks
             };
 
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data);
         }
 

--- a/js/samples/advanced-nodejs/views/math.html
+++ b/js/samples/advanced-nodejs/views/math.html
@@ -12,6 +12,8 @@
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
+    <!-- Promise polyfill is needed for IE11 support -->
+    <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 
     <link href='../css/styles.css' rel='stylesheet'>
@@ -151,7 +153,7 @@
     </main>
 
     <script type='text/javascript'>
-        async function handleLaunchImmersiveReader() {
+        function handleLaunchImmersiveReader() {
             var title = $('#IrTitle').text().trim();
 
             // Populate math chunks
@@ -178,10 +180,7 @@
                 chunks: chunks
             };
 
-            const token = await getImmersiveReaderTokenAsync();
-            const subdomain = await getSubdomainAsync();
-
-            ImmersiveReader.launchAsync(token, subdomain, data);
+            launchImmersiveReader(data);
         }
 
         // Display math preview with MathJax

--- a/js/samples/advanced-nodejs/views/multilang.html
+++ b/js/samples/advanced-nodejs/views/multilang.html
@@ -96,6 +96,8 @@
                 chunks: chunks
             };
 
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data);
         }
     </script>

--- a/js/samples/advanced-nodejs/views/multilang.html
+++ b/js/samples/advanced-nodejs/views/multilang.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
-    <!-- Promise polyfill is needed for IE11 support -->
+    <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 

--- a/js/samples/advanced-nodejs/views/multilang.html
+++ b/js/samples/advanced-nodejs/views/multilang.html
@@ -11,6 +11,8 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
+    <!-- Promise polyfill is needed for IE11 support -->
+    <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 
     <link href='../css/styles.css' rel='stylesheet'>
@@ -68,7 +70,7 @@
     </main>
 
     <script type='text/javascript'>
-        async function handleLaunchImmersiveReader() {
+        function handleLaunchImmersiveReader() {
             var title = $('#IrTitle').text().trim();
 
             var chunks = [];
@@ -94,10 +96,7 @@
                 chunks: chunks
             };
 
-            const token = await getImmersiveReaderTokenAsync();
-            const subdomain = await getSubdomainAsync();
-
-            ImmersiveReader.launchAsync(token, subdomain, data);
+            launchImmersiveReader(data);
         }
     </script>
 </body>

--- a/js/samples/advanced-nodejs/views/multilang.html
+++ b/js/samples/advanced-nodejs/views/multilang.html
@@ -96,7 +96,7 @@
                 chunks: chunks
             };
 
-            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers how to retrieve
             // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data);
         }

--- a/js/samples/advanced-nodejs/views/sections.html
+++ b/js/samples/advanced-nodejs/views/sections.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
-    <!-- Promise polyfill is needed for IE11 support -->
+    <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 

--- a/js/samples/advanced-nodejs/views/sections.html
+++ b/js/samples/advanced-nodejs/views/sections.html
@@ -10,7 +10,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
+    <script type='text/javascript' src='../js/immersive-reader-sdk.js'></script>
     <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
@@ -105,7 +105,7 @@
                 }]
             };
 
-            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers how to retrieve
             // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data);
         }

--- a/js/samples/advanced-nodejs/views/sections.html
+++ b/js/samples/advanced-nodejs/views/sections.html
@@ -105,6 +105,8 @@
                 }]
             };
 
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data);
         }
     </script>

--- a/js/samples/advanced-nodejs/views/sections.html
+++ b/js/samples/advanced-nodejs/views/sections.html
@@ -11,6 +11,8 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
+    <!-- Promise polyfill is needed for IE11 support -->
+    <!-- <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script> -->
     <script type='text/javascript' src='../js/helpers.js'></script>
 
     <link href='../css/styles.css' rel='stylesheet'>
@@ -108,6 +110,24 @@
 
             ImmersiveReader.launchAsync(token, subdomain, data);
         }
+
+        // IE11 doesn't support the async/await syntax. The code below is equivalent to the code above but works
+        // in IE11 with a Promise polyfill.
+        // function handleLaunchImmersiveReader(sampleId) {
+        //     var data = {
+        //         title: $('#title' + sampleId).text().trim(),
+        //         chunks: [{
+        //             content: $('#text' + sampleId).text().trim(),
+        //             lang: 'en'
+        //         }]
+        //     };
+        //
+        //     var token = getImmersiveReaderTokenAsync().then(function (token) {
+        //         getSubdomainAsync().then(function (subdomain) {
+        //             ImmersiveReader.launchAsync(token, subdomain, data);
+        //         });
+        //     });
+        // }
     </script>
 </body>
 </html>

--- a/js/samples/advanced-nodejs/views/sections.html
+++ b/js/samples/advanced-nodejs/views/sections.html
@@ -12,7 +12,7 @@
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
     <!-- Promise polyfill is needed for IE11 support -->
-    <!-- <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script> -->
+    <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 
     <link href='../css/styles.css' rel='stylesheet'>
@@ -96,7 +96,7 @@
     </main>
 
     <script type='text/javascript'>
-        async function handleLaunchImmersiveReader(sampleId) {
+        function handleLaunchImmersiveReader(sampleId) {
             const data = {
                 title: $('#title' + sampleId).text().trim(),
                 chunks: [{
@@ -105,29 +105,8 @@
                 }]
             };
 
-            const token = await getImmersiveReaderTokenAsync();
-            const subdomain = await getSubdomainAsync();
-
-            ImmersiveReader.launchAsync(token, subdomain, data);
+            launchImmersiveReader(data);
         }
-
-        // IE11 doesn't support the async/await syntax. The code below is equivalent to the code above but works
-        // in IE11 with a Promise polyfill.
-        // function handleLaunchImmersiveReader(sampleId) {
-        //     var data = {
-        //         title: $('#title' + sampleId).text().trim(),
-        //         chunks: [{
-        //             content: $('#text' + sampleId).text().trim(),
-        //             lang: 'en'
-        //         }]
-        //     };
-        //
-        //     var token = getImmersiveReaderTokenAsync().then(function (token) {
-        //         getSubdomainAsync().then(function (subdomain) {
-        //             ImmersiveReader.launchAsync(token, subdomain, data);
-        //         });
-        //     });
-        // }
     </script>
 </body>
 </html>

--- a/js/samples/advanced-nodejs/views/uilangs.html
+++ b/js/samples/advanced-nodejs/views/uilangs.html
@@ -11,6 +11,8 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
+    <!-- Promise polyfill is needed for IE11 support -->
+    <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 
     <link href='../css/styles.css' rel='stylesheet'>
@@ -98,7 +100,7 @@
     </main>
 
     <script type='text/javascript'>
-        async function handleLaunchImmersiveReader(sampleId) {
+        function handleLaunchImmersiveReader(sampleId) {
             const data = {
                 title: $('#title' + sampleId).text().trim(),
                 chunks: [{
@@ -113,10 +115,7 @@
                 'uiLang': uiLang
             }
 
-            const token = await getImmersiveReaderTokenAsync();
-            const subdomain = await getSubdomainAsync();
-
-            ImmersiveReader.launchAsync(token, subdomain, data, options);
+            launchImmersiveReader(data, options);
         }
     </script>
 </body>

--- a/js/samples/advanced-nodejs/views/uilangs.html
+++ b/js/samples/advanced-nodejs/views/uilangs.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.0.3.js'></script>
-    <!-- Promise polyfill is needed for IE11 support -->
+    <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
     <script type='text/javascript' src='../js/helpers.js'></script>
 

--- a/js/samples/advanced-nodejs/views/uilangs.html
+++ b/js/samples/advanced-nodejs/views/uilangs.html
@@ -115,7 +115,7 @@
                 'uiLang': uiLang
             }
 
-            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers how to retrieve
             // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data, options);
         }

--- a/js/samples/advanced-nodejs/views/uilangs.html
+++ b/js/samples/advanced-nodejs/views/uilangs.html
@@ -115,6 +115,8 @@
                 'uiLang': uiLang
             }
 
+            // Refer to the launchImmersiveReader() function in helpers.js for more information. It covers things like retrieving
+            // the Cognitive Services token, the subdomain, and usage of the launchAsync function of the Immersive Reader SDK
             launchImmersiveReader(data, options);
         }
     </script>

--- a/js/src/immersive-reader-sdk.ts
+++ b/js/src/immersive-reader-sdk.ts
@@ -5,7 +5,34 @@ import { renderButtons } from './renderButtons';
 import { close, launchAsync } from './launchAsync';
 
 window.addEventListener('load', () => {
+    if (!('Promise' in window)) {
+        dynamicallyLoadScript('https://contentstorage.onenote.office.net/onenoteltir/permanent-static-resources/promise-polyfill.min.js');
+    }
+
     renderButtons();
 });
 
-export {renderButtons, close, launchAsync};
+function dynamicallyLoadScript(scriptUrl: string) {
+    const head = document.getElementsByTagName('head')[0];
+    const script = document.createElement('script');
+    script.src = scriptUrl;
+    script.async = true;
+    let done = false;
+    script.onload = (script as any).onreadystatechange = function () {
+        // 'this' refers to the XMLHttpRequest scope, readyState is a property on 'this'
+        // tslint:disable-next-line:no-invalid-this
+        if (!done && (!this.readyState || this.readyState === 'loaded' || this.readyState === 'complete')) {
+            done = true;
+
+            // Handle memory leak in IE
+            script.onload = (script as any).onreadystatechange = null;
+            if (head && script.parentNode) {
+                head.removeChild(script);
+            }
+        }
+    };
+
+    head.appendChild(script);
+}
+
+export { renderButtons, close, launchAsync };

--- a/js/src/immersive-reader-sdk.ts
+++ b/js/src/immersive-reader-sdk.ts
@@ -5,7 +5,7 @@ import { renderButtons } from './renderButtons';
 import { close, launchAsync } from './launchAsync';
 
 window.addEventListener('load', () => {
-    if (!('Promise' in window)) {
+    if (!(window.hasOwnProperty('Promise'))) {
         dynamicallyLoadScript('https://contentstorage.onenote.office.net/onenoteltir/permanent-static-resources/promise-polyfill.min.js');
     }
 

--- a/js/src/immersive-reader-sdk.ts
+++ b/js/src/immersive-reader-sdk.ts
@@ -15,7 +15,6 @@ window.addEventListener('load', () => {
 function dynamicallyLoadScript(scriptUrl: string) {
     const script = document.createElement('script');
     script.src = scriptUrl;
-    script.async = true;
     document.head.appendChild(script);
 }
 

--- a/js/src/immersive-reader-sdk.ts
+++ b/js/src/immersive-reader-sdk.ts
@@ -13,26 +13,10 @@ window.addEventListener('load', () => {
 });
 
 function dynamicallyLoadScript(scriptUrl: string) {
-    const head = document.getElementsByTagName('head')[0];
     const script = document.createElement('script');
     script.src = scriptUrl;
     script.async = true;
-    let done = false;
-    script.onload = (script as any).onreadystatechange = function () {
-        // 'this' refers to the XMLHttpRequest scope, readyState is a property on 'this'
-        // tslint:disable-next-line:no-invalid-this
-        if (!done && (!this.readyState || this.readyState === 'loaded' || this.readyState === 'complete')) {
-            done = true;
-
-            // Handle memory leak in IE
-            script.onload = (script as any).onreadystatechange = null;
-            if (head && script.parentNode) {
-                head.removeChild(script);
-            }
-        }
-    };
-
-    head.appendChild(script);
+    document.head.appendChild(script);
 }
 
 export { renderButtons, close, launchAsync };


### PR DESCRIPTION
IE11 doesn't support Promises, async/await, or arrow functions. This change adds support in the SDK for IE11 by conditionally adding a [Promise polyfill](https://github.com/taylorhakes/promise-polyfill) as needed. The SDK typescript config targets es5, so async/await and arrow functions already get converted.

After updating the SDK, the advanced-nodejs sample also had some compatibility issues with IE11. I added the same Promise polyfill. All arrow functions in the sample were converted to regular anonymous functions. Async/await was converted to use .then() and .catch(). 