### PR TITLE
Users/rwaller/adjust timeout behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ iOSInjectionProject/
 
 # Java project files
 .project
+
+@ custom ignores
+/js/package-lock.json
+/js/yarn.lock

--- a/js/package.json
+++ b/js/package.json
@@ -7,6 +7,7 @@
   "types": "lib/immersive-reader-sdk.d.ts",
   "devDependencies": {
     "@types/jest": "^24.0.11",
+    "@types/node": "^12.12.14",
     "jest": "^24.9.00",
     "replace-in-file": "^3.4.4",
     "ts-jest": "^24.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -26,8 +26,5 @@
   },
   "jest": {
     "preset": "ts-jest"
-  },
-  "dependencies": {
-    "@types/node": "^12.12.14"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -26,5 +26,8 @@
   },
   "jest": {
     "preset": "ts-jest"
+  },
+  "dependencies": {
+    "@types/node": "^12.12.14"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/immersive-reader-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "https://github.com/Microsoft/immersive-reader-sdk",
   "license": "MIT",
   "main": "lib/immersive-reader-sdk.js",

--- a/js/src/error.ts
+++ b/js/src/error.ts
@@ -10,5 +10,6 @@ export enum ErrorCode {
     BadArgument = 'BadArgument',
     Timeout = 'Timeout',
     TokenExpired = 'TokenExpired',
-    Throttled = 'Throttled'
+    Throttled = 'Throttled',
+    ServerError = 'ServerError'
 }

--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -112,7 +112,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
             if (!e || !e.data) { return; }
 
             if (e.data === 'ImmersiveReader-ReadyForContent') {
-                resetTimeout(); // reset the timeout once the reader page loads successfully. The Reader page will report further errors through PostMessage if there is an issue obtaining the ConentModel from the server
+                resetTimeout(); // Reset the timeout once the reader page loads successfully. The Reader page will report further errors through PostMessage if there is an issue obtaining the ContentModel from the server
                 const message: Message = {
                     cogSvcsAccessToken: token,
                     cogSvcsSubdomain: subdomain,

--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -46,10 +46,10 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
             return;
         }
 
-        if (!isValidSubdomain(subdomain) && (!options || !options.customDomain)) {
-            reject({ code: ErrorCode.BadArgument, message: 'The subdomain supplied is invalid.' });
-            return;
-        }
+         if (!isValidSubdomain(subdomain) && (!options || !options.customDomain)) {
+             reject({ code: ErrorCode.BadArgument, message: 'The subdomain supplied is invalid.' });
+             return;
+         }
 
         const startTime = Date.now();
         options = {
@@ -85,6 +85,8 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
                 document.body.removeChild(iframeContainer);
             }
 
+            window.removeEventListener('message', messageHandler);
+
             // Clear the timeout timer
             resetTimeout();
 
@@ -94,21 +96,23 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
             }
         };
 
+        const exit = (): void => {
+            reset();
+
+            // Execute exit callback if we have one
+            if (options.onExit) {
+                options.onExit();
+            }
+        }
+
         // Reset variables
         reset();
 
         const messageHandler = (e: any): void => {
             if (!e || !e.data) { return; }
 
-            if (e.data === 'ImmersiveReader-Exit') {
-                reset();
-                window.removeEventListener('message', messageHandler);
-
-                // Execute exit callback if we have one
-                if (options.onExit) {
-                    options.onExit();
-                }
-            } else if (e.data === 'ImmersiveReader-ReadyForContent') {
+            if (e.data === 'ImmersiveReader-ReadyForContent') {
+                resetTimeout(); // reset the timeout once the reader page loads successfully. The Reader page will report further errors through PostMessage if there is an issue obtaining the ConentModel from the server
                 const message: Message = {
                     cogSvcsAccessToken: token,
                     cogSvcsSubdomain: subdomain,
@@ -120,14 +124,19 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
                 resetTimeout();
                 resolve(iframeContainer);
             } else if (e.data === 'ImmersiveReader-TokenExpired') {
-                reset();
+                exit();
                 reject({ code: ErrorCode.TokenExpired, message: 'The access token supplied is expired.' });
             } else if (e.data === 'ImmersiveReader-Throttled') {
-                reset();
+                exit();
                 reject({ code: ErrorCode.Throttled, message: 'You have exceeded your quota.' });
             } else if (e.data === 'ImmersiveReader-InvalidCognitiveServicesSubdomain') {
-                reset();
+                exit();
                 reject({ code: ErrorCode.BadArgument, message: 'The subdomain supplied is invalid.' });
+            } else if (e.data === 'ImmersiveReader-ServerError') {
+                exit();
+                reject({ code: ErrorCode.ServerError, message: 'An error occurred when calling the server to process the text.' });
+            }  else if (e.data === 'ImmersiveReader-Exit') {
+                exit();
             }
         };
         window.addEventListener('message', messageHandler);
@@ -151,7 +160,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
             });
         }
 
-        const domain = options.customDomain ? options.customDomain : `https://${subdomain}.cognitiveservices.azure.com/immersivereader/webapp/v1.0/`;
+		const domain = options.customDomain ? options.customDomain : `https://${subdomain}.cognitiveservices.azure.com/immersivereader/webapp/v1.0/`;
         let src = domain + 'reader?exitCallback=ImmersiveReader-Exit&sdkPlatform=' + sdkPlatform + '&sdkVersion=' + sdkVersion;
 
         if (options.hideExitButton) {

--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -46,10 +46,10 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
             return;
         }
 
-         if (!isValidSubdomain(subdomain) && (!options || !options.customDomain)) {
-             reject({ code: ErrorCode.BadArgument, message: 'The subdomain supplied is invalid.' });
-             return;
-         }
+        if (!isValidSubdomain(subdomain) && (!options || !options.customDomain)) {
+            reject({ code: ErrorCode.BadArgument, message: 'The subdomain supplied is invalid.' });
+            return;
+        }
 
         const startTime = Date.now();
         options = {

--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -160,7 +160,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
             });
         }
 
-		const domain = options.customDomain ? options.customDomain : `https://${subdomain}.cognitiveservices.azure.com/immersivereader/webapp/v1.0/`;
+        const domain = options.customDomain ? options.customDomain : `https://${subdomain}.cognitiveservices.azure.com/immersivereader/webapp/v1.0/`;
         let src = domain + 'reader?exitCallback=ImmersiveReader-Exit&sdkPlatform=' + sdkPlatform + '&sdkVersion=' + sdkVersion;
 
         if (options.hideExitButton) {

--- a/js/tests/launchAsync.test.ts
+++ b/js/tests/launchAsync.test.ts
@@ -144,30 +144,51 @@ describe('launchAsync tests', () => {
         const iframe = <HTMLIFrameElement>container.firstElementChild;
         expect(iframe.src.toLowerCase()).toMatch('https://foo.com/');
     });
+});
 
-    describe('Utility method isValidSubdomain', () => {
-        it('should return false', () => {
-            expect(isValidSubdomain(null)).toBe(false);
-            expect(isValidSubdomain(undefined)).toBe(false);
-            expect(isValidSubdomain('')).toBe(false);
-            expect(isValidSubdomain('é')).toBe(false);
-            expect(isValidSubdomain('hasaccént')).toBe(false);
-            expect(isValidSubdomain('1é2')).toBe(false);
-            expect(isValidSubdomain('É')).toBe(false);
-            expect(isValidSubdomain('Ã')).toBe(false);
-            expect(isValidSubdomain('has space')).toBe(false);
-            expect(isValidSubdomain('has.period')).toBe(false);
-            expect(isValidSubdomain(' startswithspace')).toBe(false);
-            expect(isValidSubdomain('endswithspace ')).toBe(false);
-            expect(isValidSubdomain('-startswithdash')).toBe(false);
-            expect(isValidSubdomain('endswithdash-')).toBe(false);
-        });
-
-        it('should return true', () => {
-            expect(isValidSubdomain('valid')).toBe(true);
-            expect(isValidSubdomain('valid10with2numbers')).toBe(true);
-            expect(isValidSubdomain('1234')).toBe(true);
-        });
+describe('Utility method isValidSubdomain', () => {
+    it('should return false', () => {
+        expect(isValidSubdomain(null)).toBe(false);
+        expect(isValidSubdomain(undefined)).toBe(false);
+        expect(isValidSubdomain('')).toBe(false);
+        expect(isValidSubdomain('é')).toBe(false);
+        expect(isValidSubdomain('hasaccént')).toBe(false);
+        expect(isValidSubdomain('1é2')).toBe(false);
+        expect(isValidSubdomain('É')).toBe(false);
+        expect(isValidSubdomain('Ã')).toBe(false);
+        expect(isValidSubdomain('has space')).toBe(false);
+        expect(isValidSubdomain('has.period')).toBe(false);
+        expect(isValidSubdomain(' startswithspace')).toBe(false);
+        expect(isValidSubdomain('endswithspace ')).toBe(false);
+        expect(isValidSubdomain('-startswithdash')).toBe(false);
+        expect(isValidSubdomain('endswithdash-')).toBe(false);
     });
 
+    it('should return true', () => {
+        expect(isValidSubdomain('valid')).toBe(true);
+        expect(isValidSubdomain('valid10with2numbers')).toBe(true);
+        expect(isValidSubdomain('1234')).toBe(true);
+    });
 });
+
+const fs = require('fs');
+describe('Verify SDK version is valid', () => {
+
+    it('check version', () => {
+        const packageJson: string = fs.readFileSync("package.json", "utf8");
+        const sdkVersion: string = JSON.parse(packageJson).version;
+        console.log(`SDK version: ${sdkVersion}`);
+
+        expect(isValidSDKVersion(sdkVersion)).toBe(true);
+    });
+});
+
+// sdk version must be in format xxx.xxx.xxx (each version segment between 1 and 3 digits)
+function isValidSDKVersion(sdkVersion: string): boolean {
+    if (!sdkVersion) {
+        return false;
+    }
+
+    const regExp = /^[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$/;
+    return regExp.test(sdkVersion);
+}

--- a/js/tests/launchAsync.test.ts
+++ b/js/tests/launchAsync.test.ts
@@ -173,7 +173,6 @@ describe('Utility method isValidSubdomain', () => {
 
 const fs = require('fs');
 describe('Verify SDK version is valid', () => {
-
     it('check version', () => {
         const packageJson: string = fs.readFileSync("package.json", "utf8");
         const sdkVersion: string = JSON.parse(packageJson).version;


### PR DESCRIPTION
Adjust timeout behavior to apply to Reader load only.

All GetContentModel errors not previously handled will be reported through the generic 'ServerError' PostMessage

For all errors that occur, which result in the Reader getting closed, call the OnExit callback.

Add a Unit Test to validate that the SDK version in package.json is valid.