### PR TITLE
Do not allow launchAsync to be called when already loading

### DIFF
--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -31,6 +31,8 @@ errorMessageMap[ErrorCode.Throttled] = 'You have exceeded your quota.';
 errorMessageMap[ErrorCode.ServerError] = 'An error occurred when calling the server to process the text.';
 errorMessageMap[ErrorCode.InvalidSubdomain] = 'The subdomain supplied is invalid.';
 
+let isLoading: boolean = false;
+
 /**
  * Launch the Immersive Reader within an iframe.
  * @param token The authentication token.
@@ -40,6 +42,10 @@ errorMessageMap[ErrorCode.InvalidSubdomain] = 'The subdomain supplied is invalid
  * @return A promise that resolves with a LaunchResponse when the Immersive Reader is launched.
  */
 export function launchAsync(token: string, subdomain: string, content: Content, options?: Options): Promise<LaunchResponse> {
+    if (isLoading) {
+        return Promise.reject('Immersive Reader is already launching');
+    }
+
     return new Promise((resolve, reject: (reason: Error) => void): void => {
         if (!token) {
             reject({ code: ErrorCode.BadArgument, message: 'Token must not be null' });
@@ -66,6 +72,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
             return;
         }
 
+        isLoading = true;
         const startTime = Date.now();
         options = {
             uiZIndex: 1000,
@@ -170,6 +177,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
                     };
                 }
 
+                isLoading = false;
                 if (launchResponse) {
                     resetTimeout();
                     resolve(launchResponse);
@@ -184,6 +192,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
         // Reject the promise if the Immersive Reader page fails to load.
         timeoutId = window.setTimeout((): void => {
             reset();
+            isLoading = false;
             reject({ code: ErrorCode.Timeout, message: `Page failed to load after timeout (${options.timeout} ms)` });
         }, options.timeout);
 


### PR DESCRIPTION
The Immersive Reader is essentially a modal dialog, and so you shouldn't be able to call `launchAsync` multiple times. There are a number of ways to go about preventing `launchAsync` from being called multiple times, and this PR is just one proposal. I'm not sure this is a great solution, so I'd appreciate any comments!