### PR TITLE
Add options to enable translation on load

### DIFF
--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Content } from './content';
-import { CookiePolicy, Options, ReadAloudOptions } from './options';
+import { CookiePolicy, Options, ReadAloudOptions, TranslationOptions } from './options';
 import { Error, ErrorCode } from './error';
 import { LaunchResponse } from './launchResponse';
 declare const VERSION: string;
@@ -14,6 +14,7 @@ type Message = {
     launchToPostMessageSentDurationInMs: number;
     disableFirstRun?: boolean;
     readAloudOptions?: ReadAloudOptions;
+    translationOptions?: TranslationOptions;
 };
 
 type LaunchResponseMessage = {
@@ -138,7 +139,8 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
                     request: content,
                     launchToPostMessageSentDurationInMs: Date.now() - startTime,
                     disableFirstRun: options.disableFirstRun,
-                    readAloudOptions: options.readAloudOptions
+                    readAloudOptions: options.readAloudOptions,
+                    translationOptions: options.translationOptions
                 };
                 iframe.contentWindow!.postMessage(JSON.stringify({ messageType: 'Content', messageValue: message }), '*');
             } else if (e.data === 'ImmersiveReader-Exit') {

--- a/js/src/options.ts
+++ b/js/src/options.ts
@@ -13,7 +13,7 @@ export type Options = {
     cookiePolicy?: CookiePolicy; // Setting for the Immersive Reader's cookie usage (default is CookiePolicy.Disable). It's the responsibility of the host application to obtain any necessary user consent in accordance with EU Cookie Compliance Policy.
     disableFirstRun?: boolean; // Disable the first run experience
     readAloudOptions?: ReadAloudOptions; // Options to configure Read Aloud
-    translationOptions?: TranslationOptions;
+    translationOptions?: TranslationOptions; // Options to configure Translation
 };
 
 export enum CookiePolicy { Disable, Enable }
@@ -25,7 +25,7 @@ export type ReadAloudOptions = {
 };
 
 export type TranslationOptions = {
-    language: string;
-    enableDocumentTranslation?: boolean;
-    enableWordTranslation?: boolean;
+    language: string;                       // Set the translation language, e.g. fr-FR, es-MX, zh-Hans-CN. Required to automatically enable word or document translation.
+    enableDocumentTranslation?: boolean;    // Automatically translate the entire document
+    enableWordTranslation?: boolean;        // Automatically enable word translation
 };

--- a/js/src/options.ts
+++ b/js/src/options.ts
@@ -13,6 +13,7 @@ export type Options = {
     cookiePolicy?: CookiePolicy; // Setting for the Immersive Reader's cookie usage (default is CookiePolicy.Disable). It's the responsibility of the host application to obtain any necessary user consent in accordance with EU Cookie Compliance Policy.
     disableFirstRun?: boolean; // Disable the first run experience
     readAloudOptions?: ReadAloudOptions; // Options to configure Read Aloud
+    translationOptions?: TranslationOptions;
 };
 
 export enum CookiePolicy { Disable, Enable }
@@ -21,4 +22,10 @@ export type ReadAloudOptions = {
     voice?: string;      // Voice, either 'male' or 'female'. Note that not all languages support both genders.
     speed?: number;      // Playback speed, must be between 0.5 and 2.5, inclusive.
     autoplay?: boolean;  // Automatically start Read Aloud when the Immersive Reader loads.
+};
+
+export type TranslationOptions = {
+    language: string;
+    enableDocumentTranslation?: boolean;
+    enableWordTranslation?: boolean;
 };


### PR DESCRIPTION
The changes in this PR allow for the ability to send the option to set the translation language, enable word translation, and enable document translation when launching Immersive Reader.