### PR TITLE
Fixes available region typos in v0.5.x code samples.

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -14,7 +14,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/advanced-csharp-multiple-resources/ImmersiveReaderResourceConfig.cs
+++ b/js/samples/advanced-csharp-multiple-resources/ImmersiveReaderResourceConfig.cs
@@ -13,7 +13,7 @@ namespace MultipleResourcesSampleWebApp
 
 		// The location associated with the Immersive Reader resource.
 		// The following are valid values for the region:
-		// eastus, westus, northeurope, westeurope, centralindia, japaneast, japanwest, australiaeast
+		// eastus, westus, northeurope, westeurope, centralindia, japaneast, australiaeast
 		public string Region { get; set; }
 	}
 }

--- a/js/samples/advanced-csharp-multiple-resources/ReadMe.md
+++ b/js/samples/advanced-csharp-multiple-resources/ReadMe.md
@@ -14,7 +14,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/advanced-csharp/Controllers/ApiController.cs
+++ b/js/samples/advanced-csharp/Controllers/ApiController.cs
@@ -16,7 +16,7 @@ namespace AdvancedSampleWebApp.Pages
 
         // The location associated with the Immersive Reader resource.
 		// The following are valid values for the region:
-		// eastus, westus, northeurope, westeurope, centralindia, japaneast, japanwest, australiaeast
+		// eastus, westus, northeurope, westeurope, centralindia, japaneast, australiaeast
         private readonly string Region;
 
         public ApiController(Microsoft.Extensions.Configuration.IConfiguration configuration)

--- a/js/samples/advanced-csharp/ReadMe.md
+++ b/js/samples/advanced-csharp/ReadMe.md
@@ -20,7 +20,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/advanced-nodejs/ReadMe.md
+++ b/js/samples/advanced-nodejs/ReadMe.md
@@ -14,7 +14,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/ios/README.md
+++ b/js/samples/ios/README.md
@@ -15,7 +15,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/quickstart-csharp/Controllers/HomeController.cs
+++ b/js/samples/quickstart-csharp/Controllers/HomeController.cs
@@ -17,7 +17,7 @@ namespace QuickstartSampleWebApp.Controllers
 
 		// The location associated with the Immersive Reader resource.
 		// The following are valid values for the region:
-		//   eastus, westus, northeurope, westeurope, centralindia, japaneast, japanwest, australiaeast
+		//   eastus, westus, northeurope, westeurope, centralindia, japaneast, australiaeast
 		public string Region = "";
 
 		public HomeController(Microsoft.Extensions.Configuration.IConfiguration configuration)

--- a/js/samples/quickstart-csharp/ReadMe.md
+++ b/js/samples/quickstart-csharp/ReadMe.md
@@ -15,7 +15,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/quickstart-java-android/ReadMe.md
+++ b/js/samples/quickstart-java-android/ReadMe.md
@@ -14,7 +14,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/quickstart-java/ReadMe.md
+++ b/js/samples/quickstart-java/ReadMe.md
@@ -15,7 +15,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/quickstart-kotlin/README.md
+++ b/js/samples/quickstart-kotlin/README.md
@@ -14,7 +14,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/quickstart-nodejs/ReadMe.md
+++ b/js/samples/quickstart-nodejs/ReadMe.md
@@ -14,7 +14,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/quickstart-python/ReadMe.md
+++ b/js/samples/quickstart-python/ReadMe.md
@@ -45,7 +45,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/js/samples/uwp/README.md
+++ b/js/samples/uwp/README.md
@@ -17,7 +17,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.


### PR DESCRIPTION
The code samples in the v0.5.x sdk refer to an unsupported region, removing.