### PR TITLE
Fixes available region typos in office-lens-v0.0.3-backfix code samples

### DIFF
--- a/iOS/README.md
+++ b/iOS/README.md
@@ -20,7 +20,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/iOS/samples/picture-to-immersive-reader-swift/ReadMe.md
+++ b/iOS/samples/picture-to-immersive-reader-swift/ReadMe.md
@@ -18,7 +18,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.

--- a/iOS/samples/quickstart-swift/ReadMe.md
+++ b/iOS/samples/quickstart-swift/ReadMe.md
@@ -18,7 +18,7 @@ Here are the steps:
 1. Once you have access to the Subscription created via AIRS in the Azure portal https://portal.azure.com - use it to create the Immersive Reader Resource.
 1. From the Subscription go to Resources and click the `Add` button.
 1. Search for "Immersive Reader" and click the `Create` button.
-1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `japanwest`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
+1. Provide the project details, ensuring one of the following regions is selected: `eastus`, `westus`, `northeurope`, `westeurope`, `centralindia`, `japaneast`, `australiaeast` (the Learning tools Service on OSI only supports these regions) and click next.
 1. (optional) Add any tags and click next.
 1. Review the terms and click the `Create` button (it’ll take a moment to deploy).
 1. Once deployed, click the `Go to resource` button.


### PR DESCRIPTION
The code samples in the office-lens-v0.0.3-backfix sdk refer to an unsupported region, removing.