### PR TITLE
Adds aria attributes to rendered iframe returned by launchWithoutContentAsync()

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -6,7 +6,7 @@ The Immersive Reader JavaScript SDK is a JavaScript library that allows you to e
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 
@@ -33,11 +33,11 @@ Include the library of the stable build in your web application:
 ```
 
 ```bash
-npm install @microsoft/immersive-reader-sdk@0.5.2
+npm install @microsoft/immersive-reader-sdk@0.5.3
 ```
 
 ```bash
-yarn add @microsoft/immersive-reader-sdk@0.5.2
+yarn add @microsoft/immersive-reader-sdk@0.5.3
 ```
 
 Add an HTML element to your webpage with the `immersive-reader-button` class attribute.
@@ -74,10 +74,10 @@ Clone a copy of the repo:
 git clone https://github.com/microsoft/immersive-reader-sdk
 ```
 
-Check out the v0.5.2 branch of the repo:
+Check out the v0.5.3 branch of the repo:
 
 ```bash
-git checkout origin/0.5.2-master
+git checkout origin/0.5.3-master
 ```
 
 Change to the immersive-reader-sdk directory:

--- a/js/README.md
+++ b/js/README.md
@@ -6,7 +6,7 @@ The Immersive Reader JavaScript SDK is a JavaScript library that allows you to e
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 
@@ -29,15 +29,15 @@ You can find examples of how to acquire an authentication token in the [samples]
 Include the library of the stable build in your web application:
 
 ```html
-<script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+<script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
 ```
 
 ```bash
-npm install @microsoft/immersive-reader-sdk@0.5.3
+npm install @microsoft/immersive-reader-sdk@0.5.4
 ```
 
 ```bash
-yarn add @microsoft/immersive-reader-sdk@0.5.3
+yarn add @microsoft/immersive-reader-sdk@0.5.4
 ```
 
 Add an HTML element to your webpage with the `immersive-reader-button` class attribute.
@@ -74,10 +74,10 @@ Clone a copy of the repo:
 git clone https://github.com/microsoft/immersive-reader-sdk
 ```
 
-Check out the v0.5.3 branch of the repo:
+Check out the v0.5.4 branch of the repo:
 
 ```bash
-git checkout origin/0.5.3-master
+git checkout origin/0.5.4-master
 ```
 
 Change to the immersive-reader-sdk directory:

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/immersive-reader-sdk",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "homepage": "https://github.com/Microsoft/immersive-reader-sdk",
   "license": "MIT",
   "main": "lib/immersive-reader-sdk.js",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/immersive-reader-sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "homepage": "https://github.com/Microsoft/immersive-reader-sdk",
   "license": "MIT",
   "main": "lib/immersive-reader-sdk.js",

--- a/js/samples/advanced-csharp-multiple-resources/ReadMe.md
+++ b/js/samples/advanced-csharp-multiple-resources/ReadMe.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/advanced-csharp-multiple-resources/ReadMe.md
+++ b/js/samples/advanced-csharp-multiple-resources/ReadMe.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/advanced-csharp-multiple-resources/Views/Home/Index.cshtml
+++ b/js/samples/advanced-csharp-multiple-resources/Views/Home/Index.cshtml
@@ -2,7 +2,7 @@
 <head>
     <meta charset='utf-8'>
     <title>Immersive Reader Example: Document</title>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
     <meta name='viewport' content='width=device-width, initial-scale=1'>
 </head>
 <body>

--- a/js/samples/advanced-csharp/Pages/Document.cshtml
+++ b/js/samples/advanced-csharp/Pages/Document.cshtml
@@ -13,7 +13,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/Index.cshtml
+++ b/js/samples/advanced-csharp/Pages/Index.cshtml
@@ -14,7 +14,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/Math.cshtml
+++ b/js/samples/advanced-csharp/Pages/Math.cshtml
@@ -14,7 +14,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML'></script>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/MultiLang.cshtml
+++ b/js/samples/advanced-csharp/Pages/MultiLang.cshtml
@@ -13,7 +13,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/UILangs.cshtml
+++ b/js/samples/advanced-csharp/Pages/UILangs.cshtml
@@ -13,7 +13,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/WordDoc.cshtml
+++ b/js/samples/advanced-csharp/Pages/WordDoc.cshtml
@@ -12,7 +12,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/ReadMe.md
+++ b/js/samples/advanced-csharp/ReadMe.md
@@ -12,7 +12,7 @@ This sample also demonstrates how to use a canary to improve security in your we
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/advanced-csharp/ReadMe.md
+++ b/js/samples/advanced-csharp/ReadMe.md
@@ -12,7 +12,7 @@ This sample also demonstrates how to use a canary to improve security in your we
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/advanced-nodejs/ReadMe.md
+++ b/js/samples/advanced-nodejs/ReadMe.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/advanced-nodejs/ReadMe.md
+++ b/js/samples/advanced-nodejs/ReadMe.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/advanced-nodejs/views/document.html
+++ b/js/samples/advanced-nodejs/views/document.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.4 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support. -->

--- a/js/samples/advanced-nodejs/views/document.html
+++ b/js/samples/advanced-nodejs/views/document.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.2 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support. -->

--- a/js/samples/advanced-nodejs/views/math.html
+++ b/js/samples/advanced-nodejs/views/math.html
@@ -12,7 +12,7 @@
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.4 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support -->

--- a/js/samples/advanced-nodejs/views/math.html
+++ b/js/samples/advanced-nodejs/views/math.html
@@ -12,7 +12,7 @@
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.2 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support -->

--- a/js/samples/advanced-nodejs/views/multilang.html
+++ b/js/samples/advanced-nodejs/views/multilang.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.4 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support -->

--- a/js/samples/advanced-nodejs/views/multilang.html
+++ b/js/samples/advanced-nodejs/views/multilang.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.2 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support -->

--- a/js/samples/advanced-nodejs/views/sections.html
+++ b/js/samples/advanced-nodejs/views/sections.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.4 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support -->

--- a/js/samples/advanced-nodejs/views/sections.html
+++ b/js/samples/advanced-nodejs/views/sections.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.2 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support -->

--- a/js/samples/advanced-nodejs/views/uilangs.html
+++ b/js/samples/advanced-nodejs/views/uilangs.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.4 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support -->

--- a/js/samples/advanced-nodejs/views/uilangs.html
+++ b/js/samples/advanced-nodejs/views/uilangs.html
@@ -11,7 +11,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
 
-    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.2 library available on the cdn. -->
+    <!-- Use the local library built through 'yarn build:dev'. In production, use the v0.5.3 library available on the cdn. -->
     <script type='text/javascript' src='../js/immersive-reader-sdk.local.js'></script>
     
     <!-- A polyfill for Promise is needed for IE11 support -->

--- a/js/samples/ios/README.md
+++ b/js/samples/ios/README.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/ios/README.md
+++ b/js/samples/ios/README.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/ios/quickstart-swift/Resources/ImmersiveReader.html
+++ b/js/samples/ios/quickstart-swift/Resources/ImmersiveReader.html
@@ -6,7 +6,7 @@ Licensed under the MIT License. -->
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <script type="text/javascript" src="https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js"></script>
+    <script type="text/javascript" src="https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js"></script>
     <script type="text/javascript">
         function launchImmersiveReader(message) {
             if (!message) {

--- a/js/samples/quickstart-csharp/ReadMe.md
+++ b/js/samples/quickstart-csharp/ReadMe.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-csharp/ReadMe.md
+++ b/js/samples/quickstart-csharp/ReadMe.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-csharp/Views/Home/Index.cshtml
+++ b/js/samples/quickstart-csharp/Views/Home/Index.cshtml
@@ -62,7 +62,7 @@
 
 @section Scripts
 {
-    <script src="https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js"></script>
+    <script src="https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js"></script>
     <script>
         function getTokenAsync() {
             return new Promise(function (resolve, reject) {

--- a/js/samples/quickstart-java-android/ReadMe.md
+++ b/js/samples/quickstart-java-android/ReadMe.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-java-android/ReadMe.md
+++ b/js/samples/quickstart-java-android/ReadMe.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-java-android/app/src/main/assets/immersiveReader.html
+++ b/js/samples/quickstart-java-android/app/src/main/assets/immersiveReader.html
@@ -6,7 +6,7 @@ Licensed under the MIT License. -->
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <script type="text/javascript" src="https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js"></script>
+    <script type="text/javascript" src="https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js"></script>
 </head>
 <body>
     <script type="text/javascript">

--- a/js/samples/quickstart-java/ReadMe.md
+++ b/js/samples/quickstart-java/ReadMe.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-java/ReadMe.md
+++ b/js/samples/quickstart-java/ReadMe.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-java/src/main/webapp/index.jsp
+++ b/js/samples/quickstart-java/src/main/webapp/index.jsp
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="/resources/site.css" />
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
     <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
 

--- a/js/samples/quickstart-kotlin/README.md
+++ b/js/samples/quickstart-kotlin/README.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-kotlin/README.md
+++ b/js/samples/quickstart-kotlin/README.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-kotlin/app/src/main/assets/immersiveReader.html
+++ b/js/samples/quickstart-kotlin/app/src/main/assets/immersiveReader.html
@@ -6,7 +6,7 @@ Licensed under the MIT License. -->
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <script type="text/javascript" src="https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js"></script>
+    <script type="text/javascript" src="https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js"></script>
 </head>
 <body>
     <script type="text/javascript">

--- a/js/samples/quickstart-nodejs/ReadMe.md
+++ b/js/samples/quickstart-nodejs/ReadMe.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-nodejs/ReadMe.md
+++ b/js/samples/quickstart-nodejs/ReadMe.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-nodejs/views/index.pug
+++ b/js/samples/quickstart-nodejs/views/index.pug
@@ -8,7 +8,7 @@ html
       // A polyfill for Promise is needed for IE11 support.
       script(src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js')
 
-      script(src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js')
+      script(src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js')
       script(src='https://code.jquery.com/jquery-3.3.1.min.js')
 
       style(type="text/css").

--- a/js/samples/quickstart-python/ReadMe.md
+++ b/js/samples/quickstart-python/ReadMe.md
@@ -37,7 +37,7 @@
 
 ### Windows Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-python/ReadMe.md
+++ b/js/samples/quickstart-python/ReadMe.md
@@ -37,7 +37,7 @@
 
 ### Windows Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK and the SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/quickstart-python/templates/index.html
+++ b/js/samples/quickstart-python/templates/index.html
@@ -9,7 +9,7 @@
         <title>Immersive Reader Python Quickstart</title>
 
         <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
-        <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+        <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
 
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" />
         <style type="text/css">

--- a/js/samples/uwp/ImmersiveReader/script.html
+++ b/js/samples/uwp/ImmersiveReader/script.html
@@ -1,7 +1,7 @@
 ﻿<html>
 <head>
     <meta charset='utf-8'>
-    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.3.js'></script>
+    <script type='text/javascript' src='https://contentstorage.onenote.office.net/onenoteltir/immersivereadersdk/immersive-reader-sdk.0.5.4.js'></script>
     <meta name='viewport' content='width=device-width, initial-scale=1'>
 </head>
 

--- a/js/samples/uwp/README.md
+++ b/js/samples/uwp/README.md
@@ -9,7 +9,7 @@ The ImmersiveReaderView control is a Windows Runtime component that allows you t
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.4` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/samples/uwp/README.md
+++ b/js/samples/uwp/README.md
@@ -9,7 +9,7 @@ The ImmersiveReaderView control is a Windows Runtime component that allows you t
 
 ## Usage
 
-Microsoft 1st Party Office applications should use the `v0.5.2` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
+Microsoft 1st Party Office applications should use the `v0.5.3` Immersive Reader JavaScript SDK, this SDK's authentication token is retrieved by providing a `SubscriptionKey` and `Region`. This will ensure the Immersive Reader uses Office compliant APIs deployed to OSI.
 
 Here are the steps:
 

--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -327,6 +327,8 @@ export function launchWithoutContentAsync(options?: Options): Promise<LaunchWith
     const iframeContainer: HTMLDivElement = document.createElement('div');
     const iframe: HTMLIFrameElement = options.useWebview ? <HTMLIFrameElement>document.createElement('webview') : document.createElement('iframe');
     iframe.allow = 'autoplay';
+    iframe.title = 'Immersive Reader Frame';
+    iframe.setAttribute('aria-modal', 'true');
     const noscroll: HTMLStyleElement = document.createElement('style');
     noscroll.innerHTML = 'body{height:100%;overflow:hidden;}';
 


### PR DESCRIPTION
Adds aria attributes to rendered iframe returned by launchWithoutContentAsync() and updates all version references to 0.5.4 (v0.5.3 has been deprecated as its missing these attributes in the no content scenario).