### PR TITLE
adding cognitiveAppId option

### DIFF
--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -100,13 +100,26 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
         isLoading = true;
         const startTime = Date.now();
         options = {
+            ...options,
+            // FIXME: options should be set to not override existing props, not sure how this hasnt broken anything yet...
+            // Is there a reason this was set last?
+            // let a = {
+            //     b: 'b',
+            //     d: 'd'
+            //   }
+
+            //   let x = {
+            //     ...a,
+            //     b: 'c',
+            //   }
+            //   console.log(x)              
+            // this should yield { b: 'c', d: 'd'} -> current logic youd get { b: 'b', d: 'd'} and lose the spread operation values
             uiZIndex: 1000,
             timeout: 15000,  // Default to 15 seconds
             useWebview: false,
             allowFullscreen: true,
             hideExitButton: false,
             cookiePolicy: CookiePolicy.Disable,
-            ...options
         };
 
         // Ensure that we were given a number for the UI z-index
@@ -281,6 +294,10 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
 
         if (options.uiLang) {
             src += '&omkt=' + options.uiLang;
+        }
+
+        if (options.cognitiveAppId) {
+            src += '&cognitiveAppId=' + options.cognitiveAppId;
         }
 
         iframe.src = src;

--- a/js/src/options.ts
+++ b/js/src/options.ts
@@ -18,6 +18,7 @@ export type Options = {
     displayOptions?: DisplayOptions;         // Options to configure text size, font, etc.
     preferences?: string;                           // String returned from onPreferencesChanged representing the user's preferences in the Immersive Reader.
     onPreferencesChanged?: (value: string) => any;  // Executes when the user's preferences have changed.
+    cognitiveAppId?: string;             // String to delineate for 1st party application to hide MS logo (i.e. 'Teams' - default is 'Cognitive').
 };
 
 export enum CookiePolicy { Disable, Enable }


### PR DESCRIPTION
These changes have been made in the web app to accomodate these changes in the internal sdk


We allow internal teams to share a cognitiveAppId ("app id") to help us delineate if they are truly a cognitive service or rather an internal party.
- This knowledge is needed for us to make in-app specific experiences 
