### PR TITLE
adding cognitiveAppId option to this branch

### DIFF
--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -83,13 +83,13 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
         isLoading = true;
         const startTime = Date.now();
         options = {
+            ...options, // I made this same change in other branch, this is how we preserve already existing settings and dont override the presets below
             uiZIndex: 1000,
             timeout: 15000,  // Default to 15 seconds
             useWebview: false,
             allowFullscreen: true,
             hideExitButton: false,
             cookiePolicy: CookiePolicy.Disable,
-            ...options
         };
 
         // Ensure that we were given a number for the UI z-index
@@ -244,6 +244,10 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
 
         if (options.uiLang) {
             src += '&omkt=' + options.uiLang;
+        }
+
+        if (options.cognitiveAppId) {
+            src += '&cognitiveAppId=' + options.cognitiveAppId;
         }
 
         iframe.src = src;

--- a/js/src/options.ts
+++ b/js/src/options.ts
@@ -18,6 +18,7 @@ export type Options = {
     displayOptions?: DisplayOptions;         // Options to configure text size, font, etc.
     preferences?: string;                           // String returned from onPreferencesChanged representing the user's preferences in the Immersive Reader.
     onPreferencesChanged?: (value: string) => any;  // Executes when the user's preferences have changed.
+    cognitiveAppId?: string;             // String to delineate for 1st party application to hide MS logo (i.e. 'Teams' - default is 'Cognitive').
 };
 
 export enum CookiePolicy { Disable, Enable }


### PR DESCRIPTION
These changes have been made in the web app to accomodate these changes in the public sdk

We allow internal teams to share a cognitiveAppId ("app id") to help us delineate if they are truly a cognitive service or rather an internal party.

This knowledge is needed for us to make in-app specific experiences
