### PR TITLE
Set isLoading to false when exiting

### DIFF
--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -132,6 +132,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
 
         const exit = (): void => {
             reset();
+            isLoading = false;
 
             // Execute exit callback if we have one
             if (options.onExit) {


### PR DESCRIPTION
fixes https://github.com/microsoft/immersive-reader-sdk/issues/257

I tested this on our local use of the SDK and it works for us :) 

The issue was that if users don't have internet when launching, and back out before the timeout hits, then isLoading never gets set to false. This change adds it when you call exit, so you can always try to relaunch.