### PR TITLE
Bumps version back to 1.1.0 while preserving the CDN update

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -13,7 +13,7 @@ You can find examples of how to acquire an authentication token in the [samples]
 Include the library of the stable build in your web application:
 
 ```html
-<script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+<script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
 ```
 
 ```bash

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/immersive-reader-sdk",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/Microsoft/immersive-reader-sdk",
   "license": "MIT",
   "main": "lib/immersive-reader-sdk.js",

--- a/js/samples/advanced-csharp-multiple-resources/Views/Home/Index.cshtml
+++ b/js/samples/advanced-csharp-multiple-resources/Views/Home/Index.cshtml
@@ -2,7 +2,7 @@
 <head>
     <meta charset='utf-8'>
     <title>Immersive Reader Example: Document</title>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
     <meta name='viewport' content='width=device-width, initial-scale=1'>
 </head>
 <body>

--- a/js/samples/advanced-csharp/Pages/Document.cshtml
+++ b/js/samples/advanced-csharp/Pages/Document.cshtml
@@ -13,7 +13,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/Index.cshtml
+++ b/js/samples/advanced-csharp/Pages/Index.cshtml
@@ -14,7 +14,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/Math.cshtml
+++ b/js/samples/advanced-csharp/Pages/Math.cshtml
@@ -14,7 +14,7 @@
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
     <script type='text/javascript' async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML'></script>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/MultiLang.cshtml
+++ b/js/samples/advanced-csharp/Pages/MultiLang.cshtml
@@ -13,7 +13,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/UILangs.cshtml
+++ b/js/samples/advanced-csharp/Pages/UILangs.cshtml
@@ -13,7 +13,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/advanced-csharp/Pages/WordDoc.cshtml
+++ b/js/samples/advanced-csharp/Pages/WordDoc.cshtml
@@ -12,7 +12,7 @@
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js'></script>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
     <script type='text/javascript' src='~/js/helpers.js'></script>
 
     <link href='~/css/styles.css' rel='stylesheet'>

--- a/js/samples/ember-sample/app/index.html
+++ b/js/samples/ember-sample/app/index.html
@@ -10,7 +10,7 @@
 
   <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
   <script type='text/javascript'
-    src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" />
 
   {{content-for "head"}}

--- a/js/samples/ember-sample/package.json
+++ b/js/samples/ember-sample/package.json
@@ -67,6 +67,6 @@
     "edition": "octane"
   },
   "dependencies": {
-    "@microsoft/immersive-reader-sdk": "^1.2.0"
+    "@microsoft/immersive-reader-sdk": "^1.1.0"
   }
 }

--- a/js/samples/ios/quickstart-swift/Resources/ImmersiveReader.html
+++ b/js/samples/ios/quickstart-swift/Resources/ImmersiveReader.html
@@ -6,7 +6,7 @@ Licensed under the MIT License. -->
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <script type="text/javascript" src="https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js"></script>
+    <script type="text/javascript" src="https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js"></script>
     <script type="text/javascript">
         function launchImmersiveReader(message) {
             if (!message) {

--- a/js/samples/quickstart-csharp/Views/Home/Index.cshtml
+++ b/js/samples/quickstart-csharp/Views/Home/Index.cshtml
@@ -62,7 +62,7 @@
 
 @section Scripts
 {
-    <script src="https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js"></script>
+    <script src="https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js"></script>
     <script>
         function getTokenAndSubdomainAsync() {
             return new Promise(function (resolve, reject) {

--- a/js/samples/quickstart-java-android/app/src/main/assets/immersiveReader.html
+++ b/js/samples/quickstart-java-android/app/src/main/assets/immersiveReader.html
@@ -6,7 +6,7 @@ Licensed under the MIT License. -->
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <script type="text/javascript" src="https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js"></script>
+    <script type="text/javascript" src="https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js"></script>
 </head>
 <body>
     <script type="text/javascript">

--- a/js/samples/quickstart-java/src/main/webapp/index.jsp
+++ b/js/samples/quickstart-java/src/main/webapp/index.jsp
@@ -6,7 +6,7 @@
     <meta name='viewport' content='width=device-width, initial-scale=1'>
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
     <!-- A polyfill for Promise is needed for IE11 support -->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js'></script>
 

--- a/js/samples/quickstart-kotlin/app/src/main/assets/immersiveReader.html
+++ b/js/samples/quickstart-kotlin/app/src/main/assets/immersiveReader.html
@@ -6,7 +6,7 @@ Licensed under the MIT License. -->
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <script type="text/javascript" src="https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js"></script>
+    <script type="text/javascript" src="https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js"></script>
 </head>
 <body>
     <script type="text/javascript">

--- a/js/samples/quickstart-nodejs/views/index.pug
+++ b/js/samples/quickstart-nodejs/views/index.pug
@@ -10,7 +10,7 @@ html
       // A polyfill for Promise is needed for IE11 support.
       script(src='https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js')
 
-      script(src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js')
+      script(src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js')
       script(src='https://code.jquery.com/jquery-3.3.1.min.js')
 
       style(type="text/css").

--- a/js/samples/quickstart-python/templates/index.html
+++ b/js/samples/quickstart-python/templates/index.html
@@ -9,7 +9,7 @@
         <title>Immersive Reader Python Quickstart</title>
 
         <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
-        <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+        <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
 
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" />
         <style type="text/css">

--- a/js/samples/react-sample-server/client/package.json
+++ b/js/samples/react-sample-server/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@microsoft/immersive-reader-sdk": "^1.2.0",
+    "@microsoft/immersive-reader-sdk": "^1.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/js/samples/react-sample-server/client/public/index.html
+++ b/js/samples/react-sample-server/client/public/index.html
@@ -20,7 +20,7 @@
     <title>Immersive Reader React Quickstart</title>
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" />
 

--- a/js/samples/react-sample-simple/package.json
+++ b/js/samples/react-sample-simple/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@microsoft/immersive-reader-sdk": "^1.2.0",
+    "@microsoft/immersive-reader-sdk": "^1.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/js/samples/react-sample-simple/public/index.html
+++ b/js/samples/react-sample-simple/public/index.html
@@ -22,7 +22,7 @@
     <title>Immersive Reader React Quickstart</title>
 
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.3.1.min.js'></script>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" />
 

--- a/js/samples/uwp/ImmersiveReader/script.html
+++ b/js/samples/uwp/ImmersiveReader/script.html
@@ -1,7 +1,7 @@
 ﻿<html>
 <head>
     <meta charset='utf-8'>
-    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.2.0.js'></script>
+    <script type='text/javascript' src='https://ircdname.azureedge.net/immersivereadersdk/immersive-reader-sdk.1.1.0.js'></script>
     <meta name='viewport' content='width=device-width, initial-scale=1'>
 </head>
 


### PR DESCRIPTION
IMPORTANT: Need to bump all references up to 1.2.0 as soon as the artifacts are published to CDN and BEFORE publishing to NPM. Once published to NPM, tag the commit and update tagged version notes to reflect the same information as the release notes in the Microsoft Docs site.