### PR TITLE
Dependabot alerts - Bump node-forge and markdown-it version for react and ember samples

### DIFF
--- a/js/samples/ember-sample/package-lock.json
+++ b/js/samples/ember-sample/package-lock.json
@@ -8025,7 +8025,7 @@
         "json-stable-stringify": "^1.0.1",
         "leek": "0.0.24",
         "lodash.template": "^4.5.0",
-        "markdown-it": "^12.0.4",
+        "markdown-it": "^12.3.2",
         "markdown-it-terminal": "0.2.1",
         "minimatch": "^3.0.4",
         "morgan": "^1.10.0",

--- a/js/samples/ember-sample/package.json
+++ b/js/samples/ember-sample/package.json
@@ -67,6 +67,7 @@
     "edition": "octane"
   },
   "dependencies": {
-    "@microsoft/immersive-reader-sdk": "^1.1.0"
+    "@microsoft/immersive-reader-sdk": "^1.2.0",
+    "markdown-it": "^12.3.2"
   }
 }

--- a/js/samples/react-sample-server/client/package.json
+++ b/js/samples/react-sample-server/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@microsoft/immersive-reader-sdk": "^1.2.0",
+    "node-forge": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/js/samples/react-sample-server/client/yarn.lock
+++ b/js/samples/react-sample-server/client/yarn.lock
@@ -1495,6 +1495,8 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@microsoft/immersive-reader-sdk/-/immersive-reader-sdk-1.2.0.tgz#fdd6ec7f9715f77558fb8e91c03d5fb39ad9540c"
   integrity sha512-SRd3D8zY2r0Uun0dF0tDGdqx8wN0t7NteHVZT+cxTXvzw4jAcl9HtKMrgo39VcWyHCGCyF9Hzzk28mhT/q6vVg==
+  dependencies:
+    json-schema "^0.4.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -7490,10 +7492,10 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"
+  integrity sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==
 
 node-int64@^0.4.0:
   version "0.4.0"

--- a/js/samples/react-sample-simple/package.json
+++ b/js/samples/react-sample-simple/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "dependencies": {
     "@microsoft/immersive-reader-sdk": "^1.1.0",
+    "follow-redirects": "^1.14.7",
+    "node-forge": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/js/samples/react-sample-simple/yarn.lock
+++ b/js/samples/react-sample-simple/yarn.lock
@@ -1495,6 +1495,8 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@microsoft/immersive-reader-sdk/-/immersive-reader-sdk-1.2.0.tgz#fdd6ec7f9715f77558fb8e91c03d5fb39ad9540c"
   integrity sha512-SRd3D8zY2r0Uun0dF0tDGdqx8wN0t7NteHVZT+cxTXvzw4jAcl9HtKMrgo39VcWyHCGCyF9Hzzk28mhT/q6vVg==
+  dependencies:
+    json-schema "^0.4.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -5108,10 +5110,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
-  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+follow-redirects@^1.14.7:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -6816,6 +6818,11 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
+json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -7490,10 +7497,10 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"
+  integrity sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
fix low and moderate dependabot alerts on ember and react samples