### PR TITLE
Bump ansi-html from 0.0.7 to 0.0.9 in react and ember samples

### DIFF
--- a/js/samples/ember-sample/package-lock.json
+++ b/js/samples/ember-sample/package-lock.json
@@ -3002,9 +3002,9 @@
       }
     },
     "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+      "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
       "dev": true
     },
     "ansi-regex": {
@@ -4756,7 +4756,7 @@
         "@types/chai": "^4.2.9",
         "@types/chai-as-promised": "^7.1.2",
         "@types/express": "^4.17.2",
-        "ansi-html": "^0.0.7",
+        "ansi-html": "^0.0.9",
         "broccoli-node-info": "^2.1.0",
         "broccoli-slow-trees": "^3.0.1",
         "broccoli-source": "^3.0.0",
@@ -5563,7 +5563,7 @@
       "integrity": "sha512-BK8aPhQpOLsHWiftrqXQr84XsvzUqeaN4PlCQOYg5yM0M+WKAHtX2WFXmicSQZOVgKDyh5aeoNTFkHjBAEBzwQ==",
       "dev": true,
       "requires": {
-        "ansi-html": "^0.0.7",
+        "ansi-html": "^0.0.9",
         "handlebars": "^4.0.4",
         "has-ansi": "^3.0.0",
         "mime-types": "^2.1.18"

--- a/js/samples/react-sample-server/client/yarn.lock
+++ b/js/samples/react-sample-server/client/yarn.lock
@@ -1538,7 +1538,7 @@
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
   integrity sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==
   dependencies:
-    ansi-html "^0.0.7"
+    ansi-html "^0.0.9"
     error-stack-parser "^2.0.6"
     html-entities "^1.2.1"
     native-url "^0.2.6"
@@ -2354,10 +2354,10 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@0.0.7, ansi-html@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
+ansi-html@0.0.9, ansi-html@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz"
+  integrity sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -11040,7 +11040,7 @@ webpack-dev-server@3.11.1:
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz#c74028bf5ba8885aaf230e48a20e8936ab8511f0"
   integrity sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==
   dependencies:
-    ansi-html "0.0.7"
+    ansi-html "0.0.9"
     bonjour "^3.5.0"
     chokidar "^2.1.8"
     compression "^1.7.4"

--- a/js/samples/react-sample-simple/yarn.lock
+++ b/js/samples/react-sample-simple/yarn.lock
@@ -1538,7 +1538,7 @@
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
   integrity sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==
   dependencies:
-    ansi-html "^0.0.7"
+    ansi-html "^0.0.9"
     error-stack-parser "^2.0.6"
     html-entities "^1.2.1"
     native-url "^0.2.6"
@@ -2354,10 +2354,10 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@0.0.7, ansi-html@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
+ansi-html@0.0.9, ansi-html@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz"
+  integrity sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -11045,7 +11045,7 @@ webpack-dev-server@3.11.1:
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz#c74028bf5ba8885aaf230e48a20e8936ab8511f0"
   integrity sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==
   dependencies:
-    ansi-html "0.0.7"
+    ansi-html "0.0.9"
     bonjour "^3.5.0"
     chokidar "^2.1.8"
     compression "^1.7.4"


### PR DESCRIPTION
Files updated to solve high severity alert

        modified:   ember-sample/package-lock.json
        modified:   react-sample-server/client/yarn.lock
        modified:   react-sample-simple/yarn.lock