### PR TITLE
Java sample: Fix cross-site scripting vulnerability

### DIFF
--- a/js/samples/quickstart-java/pom.xml
+++ b/js/samples/quickstart-java/pom.xml
@@ -31,6 +31,12 @@
       <version>5.1.3</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.9</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/js/samples/quickstart-java/src/main/java/Microsoft/ImmersiveReader/GetAuthTokenServlet.java
+++ b/js/samples/quickstart-java/src/main/java/Microsoft/ImmersiveReader/GetAuthTokenServlet.java
@@ -5,6 +5,8 @@ import javax.servlet.http.*;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 public class GetAuthTokenServlet extends HttpServlet {
 
@@ -25,9 +27,11 @@ public class GetAuthTokenServlet extends HttpServlet {
         }
 
         String token = getToken();
+        httpServletResponse.setContentType("application/json");
+        JsonObject tokenJson = JsonParser.parseString(token).getAsJsonObject();
 
         PrintWriter writer = httpServletResponse.getWriter();
-        writer.write(token);
+        writer.write(tokenJson.toString());
         writer.flush();
     }
 

--- a/js/samples/quickstart-java/src/main/webapp/resources/helpers.js
+++ b/js/samples/quickstart-java/src/main/webapp/resources/helpers.js
@@ -1,21 +1,20 @@
 function getTokenAsync() {
-    return new Promise(function (resolve, reject) {
-        $.ajax({
-            url: '/getAuthTokenServlet',
-            type: 'GET',
-            success: function (response) {
-                const data = JSON.parse(response);
-
-                if (data.error) {
-                    reject(data.error);
-                } else {
-                    const token = data['access_token'];
-                    resolve({token});
-                }
-            },
-            error: function (err) {
-                reject(err);
-            }
-        });
+  return new Promise(function (resolve, reject) {
+    $.ajax({
+      url: "/getAuthTokenServlet",
+      type: "GET",
+      success: function (response) {
+        const data = response;
+        if (data.error) {
+          reject(data.error);
+        } else {
+          const token = data["access_token"];
+          resolve({ token });
+        }
+      },
+      error: function (err) {
+        reject(err);
+      },
     });
+  });
 }


### PR DESCRIPTION
The token returned is in JSON format, so instead of writing it directly to the response, now is set the appropriate content type (application/json) and write the token securely without modifying it.