### PR TITLE
fixed low alert

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -39,7 +39,6 @@
     "json-schema": "^0.4.0",
     "loader-utils": "^3.2.1",
     "minimatch": "3.1.4",
-    "string_decoder": "^1.3.0",
     "terser": "^5.14.2"
   },
   "resolutions": {

--- a/js/samples/ember-sample/package-lock.json
+++ b/js/samples/ember-sample/package-lock.json
@@ -25,7 +25,6 @@
         "minimatch": "3.0.5",
         "minimist": "^1.2.7",
         "socket.io": "^4.6.2",
-        "string_decoder": "^1.3.0",
         "testem": "^3.9.0"
       },
       "devDependencies": {

--- a/js/samples/ember-sample/package.json
+++ b/js/samples/ember-sample/package.json
@@ -76,7 +76,6 @@
     "minimatch": "3.0.5",
     "minimist": "^1.2.7",
     "socket.io": "^4.6.2",
-    "string_decoder": "^1.3.0",
     "testem": "^3.9.0"
   }
 }

--- a/js/samples/react-sample-server/client/package.json
+++ b/js/samples/react-sample-server/client/package.json
@@ -16,7 +16,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "shell-quote": "^1.7.4",
-    "string_decoder": "^1.3.0",
     "terser": "^5.14.2"
   },
   "devDependencies": {

--- a/js/samples/react-sample-simple/package.json
+++ b/js/samples/react-sample-simple/package.json
@@ -12,7 +12,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "shell-quote": "^1.7.3",
-    "string_decoder": "^1.3.0",
     "terser": "^5.14.2"
   },
   "devDependencies": {

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -3587,13 +3587,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string_decoder@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"


### PR DESCRIPTION
Remove unused direct dependencies on the external string_decoder npm package from the SDK and samples. Node.js provides this module natively, and no source files directly import the external package.

Changes
Removed string_decoder from four package manifests.
Removed the unused root Yarn lock entry.
Updated the Ember package lock root dependency map.
Preserved transitive string_decoder entries still required by other packages.
