### PR TITLE
Restrict Python token endpoint to loopback and enhance security docs

### DIFF
--- a/js/samples/advanced-csharp/ReadMe.md
+++ b/js/samples/advanced-csharp/ReadMe.md
@@ -6,6 +6,14 @@ This sample demonstrates more of the functionality provided by the Immersive Rea
 
 This sample also demonstrates how to use a canary to improve security in your web app. A canary is a short-lived, server-generated token, which is generated during an authenticated call to the server. Later, when the user invokes the Immersive Reader, the canary is used to authenticate the call to the server. This mechanism improves security because it adds authentication to the call to launch the Immersive Reader.
 
+## Security
+
+The pages served by `HomeController` embed a real Azure AD bearer token, minted from this sample's confidential service-principal credentials (`ClientId` / `ClientSecret` from **secrets.json**) by `GetTokenAsync()`. Anyone who can reach those pages obtains a usable Cognitive Services token. The canary described above authenticates the call that *launches* the Immersive Reader, but it does not by itself authenticate the users who can reach the app.
+
+* This sample is intended for **local development only**.
+* **Do not** expose it on a public interface or deploy it as-is without first adding authentication.
+* For any non-local or production use, gate the token-bearing actions with a real authentication mechanism, such as the `[Authorize]` attribute backed by ASP.NET Core authentication, a session check, or an authenticating API gateway in front of the app.
+
 ## Prerequisites
 
 * An Immersive Reader resource configured for Azure Active Directory authentication. Follow [these instructions](https://docs.microsoft.com/azure/applied-ai-services/immersive-reader/how-to-create-immersive-reader) to get set up. You will need some of the values created here when configuring the sample project properties. Save the output of your session into a text file for future reference.

--- a/js/samples/quickstart-csharp/ReadMe.md
+++ b/js/samples/quickstart-csharp/ReadMe.md
@@ -5,6 +5,14 @@
 * An Immersive Reader resource configured for Azure Active Directory authentication. Follow [these instructions](https://docs.microsoft.com/azure/applied-ai-services/immersive-reader/how-to-create-immersive-reader) to get set up. You will need some of the values created here when configuring the sample project properties. Save the output of your session into a text file for future reference.
 * [Visual Studio 2022](https://visualstudio.microsoft.com/downloads)
 
+## Security
+
+The pages served by `HomeController` embed a real Azure AD bearer token, minted from this sample's confidential service-principal credentials (`ClientId` / `ClientSecret` from **secrets.json**) by `GetTokenAsync()`. Anyone who can reach those pages obtains a usable Cognitive Services token, because the controller has no authentication of its own.
+
+* This sample is intended for **local development only**.
+* **Do not** expose it on a public interface or deploy it as-is without first adding authentication.
+* For any non-local or production use, gate the token-bearing actions with a real authentication mechanism, such as the `[Authorize]` attribute backed by ASP.NET Core authentication, a session check, or an authenticating API gateway in front of the app.
+
 ## Usage
 
 1. Open **QuickstartSampleWebApp.sln** in Visual Studio.

--- a/js/samples/quickstart-java/ReadMe.md
+++ b/js/samples/quickstart-java/ReadMe.md
@@ -6,6 +6,14 @@
 * [IntelliJ IDEA Community](https://www.jetbrains.com/idea/download)
 * [Java 8 JDK](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 
+## Security
+
+The `/getAuthTokenServlet` endpoint (`GetAuthTokenServlet` in **src/main/java/Microsoft/ImmersiveReader**) returns a real Azure AD bearer token, minted from this sample's confidential service-principal credentials (`CLIENT_ID` / `CLIENT_SECRET`) held in **.env**. Anyone who can reach that endpoint obtains a usable Cognitive Services token, because the servlet has no authentication of its own.
+
+* This sample is intended for **local development only** (`http://localhost:8888`).
+* **Do not** expose it on a public interface or deploy it as-is without first adding authentication.
+* For any non-local or production use, gate the servlet with a real authentication mechanism, such as a servlet filter, container-managed security constraints in **web.xml**, a signed request, or an authenticating API gateway in front of the app.
+
 ## Usage
 
 1. Create a new project in IntelliJ by clicking **New -> Project from Existing Sources...** from the menu bar.

--- a/js/samples/quickstart-nodejs/ReadMe.md
+++ b/js/samples/quickstart-nodejs/ReadMe.md
@@ -5,6 +5,14 @@
 * An Immersive Reader resource configured for Azure Active Directory authentication. Follow [these instructions](https://docs.microsoft.com/azure/applied-ai-services/immersive-reader/how-to-create-immersive-reader) to get set up. You will need some of the values created here when configuring the sample project properties. Save the output of your session into a text file for future reference.
 * Install [Yarn](https://yarnpkg.com), [npm](https://npmjs.com)
 
+## Security
+
+The `/GetTokenAndSubdomain` route in **routes/index.js** returns a real Azure AD bearer token, minted from this sample's confidential service-principal credentials (`CLIENT_ID` / `CLIENT_SECRET`) held in **.env**. Anyone who can reach that route obtains a usable Cognitive Services token, because the route has no authentication of its own.
+
+* This sample is intended for **local development only** (`http://localhost:3000`).
+* **Do not** expose it on a public interface or deploy it as-is without first adding authentication.
+* For any non-local or production use, gate the token route with a real authentication mechanism, such as an Express authentication middleware (for example Passport.js or a session check), a signed request, or an authenticating API gateway in front of the app.
+
 ## Usage
 
 1. Open a command prompt (Windows) or terminal (OSX, Linux)

--- a/js/samples/quickstart-python/ReadMe.md
+++ b/js/samples/quickstart-python/ReadMe.md
@@ -37,6 +37,14 @@
 1. Run `pip install python-dotenv --user` to install the [python-dotenv](https://github.com/theskumar/python-dotenv) module.
 1. Run `mkdir ~/.virtualenvs` to configure a folder to store your virtual environments.
 
+## Security
+
+The `/GetTokenAndSubdomain` route in **app.py** returns a real Azure AD bearer token, minted from this sample's confidential service-principal credentials (`CLIENT_ID` / `CLIENT_SECRET`). Anyone who can reach that route obtains a usable Cognitive Services token.
+
+* This sample is **loopback-only** by default. The `_require_local()` helper in **app.py** rejects any request whose remote address is not `127.0.0.1` or `::1` with an HTTP 403.
+* **Do not** run the sample with `flask run --host=0.0.0.0`, or otherwise bind it to a public interface, without first adding real authentication. Doing so exposes the token minter to your LAN or the internet.
+* For any non-local or production use, replace `_require_local()` with a real authentication mechanism, such as a login-required decorator, a session check, a signed request, or an authenticating API gateway in front of the app.
+
 ## Usage
 
 ### Windows Usage

--- a/js/samples/quickstart-python/app.py
+++ b/js/samples/quickstart-python/app.py
@@ -3,10 +3,34 @@ import os
 import requests
 import json
 from dotenv import load_dotenv
-from flask import Flask, redirect, render_template, request, jsonify
+from flask import Flask, redirect, render_template, request, jsonify, abort
 app = Flask(__name__)
 
 load_dotenv()
+
+# ---------------------------------------------------------------------------
+# SECURITY NOTICE
+# ---------------------------------------------------------------------------
+# The /GetTokenAndSubdomain endpoint below mints a real Azure AD access token
+# from this app's confidential service-principal credentials (CLIENT_ID /
+# CLIENT_SECRET) and returns that bearer token to the caller. Any caller that
+# can reach this route obtains a usable Cognitive Services token.
+#
+# This quickstart is intended ONLY for local development on 127.0.0.1. Before
+# deploying anything derived from this sample:
+#   1. Replace the loopback check in `_require_local()` with real application
+#      authentication (e.g. a login-required decorator, session check, signed
+#      request, or API gateway in front of the app).
+#   2. Do NOT run `flask run --host=0.0.0.0` (or otherwise bind to a public
+#      interface) without first adding auth -- doing so exposes the token
+#      minter to your LAN / the internet.
+# ---------------------------------------------------------------------------
+
+def _require_local():
+	'Reject non-loopback callers. Replace with real auth for production use.'
+	if request.remote_addr not in ('127.0.0.1', '::1'):
+		abort(403, description='This sample only serves loopback requests. '
+			'Add real authentication before exposing /GetTokenAndSubdomain.')
 
 @app.route('/')
 def index():
@@ -21,6 +45,7 @@ def options():
 @app.route('/GetTokenAndSubdomain', methods=['GET'])
 def getTokenAndSubdomain():
 	'Get the access token'
+	_require_local()
 	if request.method == 'GET':
 		try:
 			headers = { 'content-type': 'application/x-www-form-urlencoded' }


### PR DESCRIPTION
This pull request adds explicit security warnings and recommendations to all Immersive Reader quickstart and advanced sample READMEs, and introduces a loopback-only access restriction in the Python quickstart sample. These changes are intended to prevent accidental exposure of confidential service-principal credentials and Azure AD bearer tokens by clarifying that the samples are for local development only and must not be deployed publicly without proper authentication.

**Security documentation and enforcement improvements:**

* All sample `ReadMe.md` files now include a **Security** section, warning that the sample endpoints/routes/controllers return real Azure AD bearer tokens and must not be exposed publicly without authentication. Each section provides concrete recommendations for securing the endpoints in production [[1]](diffhunk://#diff-1c04766ef75e91b6d72a57e0b3fc174988b4c7b9c4db48fee40cb80dd3de6dacR8-R15) [[2]](diffhunk://#diff-cd64a2d65836fb86eeea6bc1fe3920d52d6acc663f6314184652975d34227410R8-R15) [[3]](diffhunk://#diff-410ebf1b96d1483fd70ccbfb30dae2498bc2f50bdc44f44758eb827e57810c8aR9-R16) [[4]](diffhunk://#diff-7384a76b01a8cdf876a8d65c0dd39edfc3a7b66cfca4cf8f9848350050fcf37cR9-R16) [[5]](diffhunk://#diff-fb9cd56ad25720f49c7665227707cf8a65a8e98e9b20e246240de9bf5b52bd28R40-R47).
* The Python quickstart sample (`app.py`) now enforces loopback-only access to the `/GetTokenAndSubdomain` route via a new `_require_local()` helper, which aborts requests from non-local addresses with an HTTP 403. This is accompanied by prominent in-code documentation explaining the security implications and steps for production hardening [[1]](diffhunk://#diff-640c6ee56de8231867c399fa326e3ffc071ff47d203cfc8b7439831373388213L6-R34) [[2]](diffhunk://#diff-640c6ee56de8231867c399fa326e3ffc071ff47d203cfc8b7439831373388213R48).