### PR TITLE
fixed high alert nanoid

### DIFF
--- a/js/samples/react-sample-server/client/yarn.lock
+++ b/js/samples/react-sample-server/client/yarn.lock
@@ -10304,8 +10304,8 @@ nan@^2.12.1:
   integrity sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==
 
 nanoid@^3.3.11, nanoid@^3.3.12, nanoid@^3.3.16, nanoid@^3.3.8:
-  version "3.3.17"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
   integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 nanomatch@^1.2.9:

--- a/js/samples/react-sample-simple/yarn.lock
+++ b/js/samples/react-sample-simple/yarn.lock
@@ -7897,8 +7897,8 @@ nan@^2.12.1:
   integrity sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==
 
 nanoid@^3.3.11, nanoid@^3.3.12, nanoid@^3.3.16, nanoid@^3.3.8:
-  version "3.3.17"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 nanomatch@^1.2.9:


### PR DESCRIPTION
Upgraded nanoid from 3.3.17 to 3.3.18 in:

server client yarn.lock
simple sample yarn.lock